### PR TITLE
Synology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 OctoPrint-WebDavBackup.zip
+.vscode/settings.json

--- a/octoprint_webdavbackup/__init__.py
+++ b/octoprint_webdavbackup/__init__.py
@@ -67,57 +67,63 @@ class WebDavBackupPlugin(octoprint.plugin.SettingsPlugin,
             check_space = self._settings.get(["check_space"])
             upload_path = now.strftime(self._settings.get(["upload_path"]))
             upload_path = ospath.join("/", upload_path)
+
             if self._settings.get(["upload_name"]):
                 upload_name = now.strftime(self._settings.get(["upload_name"])) + ospath.splitext(backup_path)[1]
                 self._logger.debug("Filename for upload: " + upload_name)
             else:
                 upload_name = backup_name
+
             upload_file = ospath.join("/", upload_path, upload_name)
             upload_temp = ospath.join("/", upload_path, upload_name + ".tmp")
 
             # Check actual connection to the WebDAV server as the check command will not do this.
-            try:
-                # If the resource was not found
-                if check_space:
+            if check_space:
+                try:
+                    # If the resource was not found
                     dav_free = davclient.free()
                     if dav_free < 0:
                         # If we get a negative free size, this server is not returning correct value.
                         check_space = False
-                        self._logger.warning("Free space on server: " + _convert_size(dav_free) + ", it appears your server does not support reporting size correctly")
+                        self._logger.warning("Free space on server: " + _convert_size(dav_free) + ", it appears your server does not support reporting size correctly but it's still a proper way to check connectivity.")
                     else:
                         self._logger.info("Free space on server: " + _convert_size(dav_free))
+                except RemoteResourceNotFound as exception:
+                    self._logger.error("Resource was not found, something is probably wrong with your settings.")
+                    return
+                except ResponseErrorCode as exception:
+                    # Write error and exit function
+                    status = HTTPStatus(exception.code)
+                    error_switcher = {
+                        400: "Bad request",
+                        401: "Unauthorized",
+                        403: "Forbidden",
+                        404: "Not found",
+                        405: "Method not allowed",
+                        408: "Request timeout",
+                        500: "Internal error",
+                        501: "Not implemented",
+                        502: "Bad gateway",
+                        503: "Service unavailable",
+                        504: "Gateway timeout",
+                        508: "Loop detected",
+                    }
+                    if (exception.code == 401):
+                        http_error = "HTTP error 401 encountered, your credentials are most likely wrong."
+                    else:
+                        http_error = "HTTP error encountered: " + str(status.value) + " " + error_switcher.get(exception.code, status.phrase)
+                    self._logger.error(http_error)
+                    return
+                except WebDavException as exception:
+                    self._logger.error("An unexpected WebDAV error was encountered: " + exception.args)
+                    raise
+            else:
+                # Not as proper of a check as retrieving size, but it's something.
+                if davclient.check("/"):
+                    self._logger.info("Server returned WebDAV root.")
                 else:
-                    # Not as proper of a check as retrieving size, but it's something.
-                    davclient.check("/")
-            except RemoteResourceNotFound as exception:
-                self._logger.error("Resource was not found, something is probably wrong with your settings.")
-                return
-            except ResponseErrorCode as exception:
-                # Write error and exit function
-                status = HTTPStatus(exception.code)
-                error_switcher = {
-                    400: "Bad request",
-                    401: "Unauthorized",
-                    403: "Forbidden",
-                    404: "Not found",
-                    405: "Method not allowed",
-                    408: "Request timeout",
-                    500: "Internal error",
-                    501: "Not implemented",
-                    502: "Bad gateway",
-                    503: "Service unavailable",
-                    504: "Gateway timeout",
-                    508: "Loop detected",
-                }
-                if (exception.code == 401):
-                    http_error = "HTTP error 401 encountered, your credentials are most likely wrong."
-                else:
-                    http_error = "HTTP error encountered: " + str(status.value) + " " + error_switcher.get(exception.code, status.phrase)
-                self._logger.error(http_error)
-                return
-            except WebDavException as exception:
-                self._logger.error("An unexpected WebDAV error was encountered: " + exception.args)
-                raise
+                    self._logger.error("Server did not return WebDAV root, something is probably wronkg with your settings.")
+                    return
 
             backup_size = ospath.getsize(backup_path)
             self._logger.info("Backup file size: " + _convert_size(backup_size))

--- a/octoprint_webdavbackup/__init__.py
+++ b/octoprint_webdavbackup/__init__.py
@@ -56,6 +56,7 @@ class WebDavBackupPlugin(octoprint.plugin.SettingsPlugin,
                 'webdav_login':    self._settings.get(["username"]),
                 'webdav_password': self._settings.get(["password"]),
                 'webdav_timeout': self._settings.get(["timeout"]),
+                'disable_check': True
             }
 
             backup_path = payload["path"]

--- a/octoprint_webdavbackup/templates/webdavbackup_settings.jinja2
+++ b/octoprint_webdavbackup/templates/webdavbackup_settings.jinja2
@@ -34,6 +34,16 @@
                 </span>
             </div>
         </div>
+        <div class="control-group">
+            <div class="controls">
+                <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: settings.plugins.webdavbackup.check_space">{{ _('Check available space') }}
+                </label>
+                <span class="help-block">
+                    Should we check if the server has enough free space available? Not all WebDAV servers support this.
+                </span>
+            </div>
+        </div>
     </div>
     <h4>File and folder settings</h4>
     <div class="accordion-inner">
@@ -58,15 +68,5 @@
         <span class="help-block">
             Python date string formatting (%Y%m%d, %H:%M:%S) is allowed in both fields.
         </span>
-        <div class="control-group">
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.webdavbackup.check_space">{{ _('Check available space') }}
-                </label>
-                <span class="help-block">
-                    Should we check if the server has enough free space available? Not all WebDAV servers support this.
-                </span>
-            </div>
-        </div>
     </div>
 </form>

--- a/octoprint_webdavbackup/templates/webdavbackup_settings.jinja2
+++ b/octoprint_webdavbackup/templates/webdavbackup_settings.jinja2
@@ -40,7 +40,19 @@
                     <input type="checkbox" data-bind="checked: settings.plugins.webdavbackup.check_space">{{ _('Check available space') }}
                 </label>
                 <span class="help-block">
-                    Should we check if the server has enough free space available? Not all WebDAV servers support this.
+                    Should we check if the server has enough free space available?<br>
+                    Not all WebDAV servers support this.
+                </span>
+            </div>
+        </div>
+                <div class="control-group">
+            <div class="controls">
+                <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: settings.plugins.webdavbackup.check_directories">{{ _('Check server directories') }}
+                </label>
+                <span class="help-block">
+                    Should we check the server directory path prior to upload?<br>
+                    Not all WebDAV servers support this.
                 </span>
             </div>
         </div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_webdavbackup"
 plugin_name = "WebDAV Backup"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.1"
+plugin_version = "0.3.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Adds check box to disable checking of the WebDav root by webdav3 client package.
Synology (and possibly other) server(s) do not support these checks.
Set default value of all check boxes to 'ticked' to be consistent.

This change uses the webdav3.client option 'disable_check' to skip checks of the remote directory structure such as webdavroot.  This allows the OctoPrint-WebDavBackup plugin to successfully communicate with a Synology WebDav server.

Using this option skips the code which checks the destination directory structure and the ability to create a new sub-directory.  As long as the destination directory, set in the folders path, exists then the backup succeeds.

Added simple tick box to the settings page to allow users to disable checking by clearing the tick box. Changed the existing space check tick box to default 'ticked' on initial installation. This has been done to be consistent with verify certificate box so that all are initially ticked. If users have problems connecting to a WebDAV server they can clear the relevant feature 'downgrade' tick box.

Resolves edekeijzer/OctoPrint-WebDavBackup#19

[This is my first exposure to GitHub and Python coding so hopefully this potential change is useful.  I have not been able to 'get my head' around what the recursive_create_path code does to be able to offer any suggestions how to implement against a Synology server.]